### PR TITLE
Fix hashing algorithm handling

### DIFF
--- a/dicom_anonymizer/anonymization/engine.py
+++ b/dicom_anonymizer/anonymization/engine.py
@@ -196,14 +196,29 @@ class AnonymizationEngine:
         
         # Get the salt for hashing
         salt = value_config.get('salt', 'default_salt')
-        
+
+        # Get the hash algorithm
+        algorithm = value_config.get('algorithm', 'sha256').lower()
+
         # Convert original value to string if it's not already
         if not isinstance(original_value, str):
             original_value = str(original_value)
-        
+
         # Create a hash of the original value with the salt
         hash_input = f"{original_value}{salt}"
-        hash_obj = hashlib.sha256(hash_input.encode())
+
+        if algorithm == 'md5':
+            hash_obj = hashlib.md5(hash_input.encode())
+        elif algorithm == 'sha1':
+            hash_obj = hashlib.sha1(hash_input.encode())
+        elif algorithm == 'sha256':
+            hash_obj = hashlib.sha256(hash_input.encode())
+        elif algorithm == 'sha512':
+            hash_obj = hashlib.sha512(hash_input.encode())
+        else:
+            logging.warning(f"Unknown hash algorithm '{algorithm}', using sha256")
+            hash_obj = hashlib.sha256(hash_input.encode())
+
         hash_hex = hash_obj.hexdigest()
         
         # Truncate the hash if needed


### PR DESCRIPTION
## Summary
- honor user-specified hash algorithm in anonymization engine

## Testing
- `python -m py_compile dicom_anonymizer/anonymization/engine.py`
- `python -m py_compile dicom_anonymizer/**/*.py`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844a909798483308b905f1ef22477f2